### PR TITLE
bump ipfs/go-ipfs to v0.7.0

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "ipfs.dnp.dappnode.eth",
   "version": "0.2.11",
-  "upstreamVersion": "v0.6.0",
+  "upstreamVersion": "v0.7.0",
   "description": "Dappnode package responsible for providing IPFS connectivity",
   "type": "dncore",
   "architectures": ["linux/amd64", "linux/arm64"],

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     build:
       context: ./build
       args:
-        UPSTREAM_VERSION: v0.6.0
+        UPSTREAM_VERSION: v0.7.0
     image: "ipfs.dnp.dappnode.eth:0.2.10"
     container_name: DAppNodeCore-ipfs.dnp.dappnode.eth
     restart: always


### PR DESCRIPTION
Bumps upstream version

- [ipfs/go-ipfs](https://github.com/ipfs/go-ipfs) from v0.6.0 to [v0.7.0](https://github.com/ipfs/go-ipfs/releases/tag/v0.7.0)